### PR TITLE
Add link to documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # nexar-plm-connector-cs
-A C# version of the generic PLM connector
+A C# version of the generic PLM connector.
+[Documentation](https://nexardeveloper.github.io/nexar-plm-connector-cs/)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # nexar-plm-connector-cs
 A C# version of the generic PLM connector.
+
 [Documentation](https://nexardeveloper.github.io/nexar-plm-connector-cs/)


### PR DESCRIPTION
Updated README.md to include a link to github.io page as 'Documentation' link.